### PR TITLE
Update application-tips.md

### DIFF
--- a/application-tips.md
+++ b/application-tips.md
@@ -1,8 +1,13 @@
 ## Application-specific tips and tricks
 > :triangular_flag_on_post: **TODO**
-* Setting up SQL.
 * .NET in-process using Edge.js.
 * [node-windows](https://github.com/coreybutler/node-windows): Windows services, logging, and commands using Node.js.
+
+### Connecting to Microsoft SQL Server
+
+* [tedious](https://www.npmjs.com/package/tedious) - TDS client written in JavaScript, no binary dependencies
+* [mssql](https://www.npmjs.com/package/mssql) - Friendly interface wrapper around SQL clients, tedious by default.
+* [mssql-ng](https://www.npmjs.com/package/mssql) - Next generation ES6-template interface for SQL (uses mssql/tedious).
 
 ### Setting up and working with MongoDB
 
@@ -41,6 +46,13 @@ MongoClient.connect(mongoUrl, function (err, db) {
     }
 });
 ```
+
+### Azure Services
+
+* [azure](https://www.npmjs.com/package/azure) - Full client for azure
+* [azure-storage](https://www.npmjs.com/package/azure-storage) - client for Azure Storage services (Tables, Blobs, Files, Queues), which is part of the `azure` module above.
+* [azure-storage-simple](https://www.npmjs.com/package/azure-storage-simple) - Promise based interface wrapper around `azure-storage` with a simpler UI.
+
 
 ## Accessing platform APIs
 Sometimes you need to access plaform functionality for which no suitable module is available. For example your app may need to access the registry running on a Windows Server or Desktop. In this case there are 2 ways to proceed. 


### PR DESCRIPTION
Add some suggested modules for MS-SQL server and Azure (disclaimer, I wrote `azure-storage-simple` and `mssql-ng`)...

For the most part tedious is not the only actively maintained client for SQL Server, with mssql being the most used client library, and mssql-ng being a further convenience wrapper.