### PR TITLE
Fix Visual C++ Build Tools link

### DIFF
--- a/windows-environment.md
+++ b/windows-environment.md
@@ -71,7 +71,7 @@ How do you know if an npm package you want to install is a native module? Look f
 #### Prerequisites
 
 1. Visual C++ Build Environment:
-  * Option 1: Install [Visual C++ Build Tools](http://go.microsoft.com/fwlink/?LinkId=691126) using the **Default Install** option.
+  * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option.
 
   * Option 2: Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup. This also works with the free Community and Express for Desktop editions.
      


### PR DESCRIPTION
They current link goes to the wrong build tools.