### PR TITLE
added required node version for getting-started

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -2,6 +2,8 @@
 Let's start with the basics.
 
 1. Install Node.js: https://nodejs.org.
+> :bulb: This code will need at least version 5.0.0, but we encourage you to run at least version 10.0.0. If you already had node installed, make sure the version is appropriate by running `node -v`
+
 > :bulb: When you install Node.js, you'll want to ensure your `PATH` variable is set to your install path so you can call Node from anywhere.
 
 2. Create a new directory named `hello-world`, add a new `app.js` file:


### PR DESCRIPTION
The code uses two es6 features (arrow functions and template strings), which surprisingly seem to be already available in node 5: https://node.green/#ES2015-functions-arrow-functions

I also added that it's recommended to update the node version to at least 10